### PR TITLE
feat: optional bearer-token auth for HTTP transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.14] — 2026-04-29
+
+### Added
+- Optional `MCP_BEARER_TOKEN` env var for bearer-token authentication on HTTP transport
+- When set, all incoming MCP requests require `Authorization: Bearer <token>` header
+- Backward compatible: server runs without transport auth when unset (existing behavior)
+
 ## [0.3.13] — 2026-04-22
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@
 4. Make your changes — keep commits focused.
 5. Run `ruff check src/ tests/` and `ruff format --check src/ tests/` to pass lint.
 6. Run `pytest` and ensure all tests pass.
-7. Open a pull request against `dev`.
+7. Open a pull request against `main`.
 
 ## Developer Certificate of Origin (DCO)
 
@@ -81,7 +81,7 @@ Pull requests are merged using **merge commits** to preserve full history.
 
 - `ruff check` and `ruff format --check` must pass.
 - `pytest tests/ -v` must pass.
-- Both run automatically in GitHub Actions on every push/PR to `dev`.
+- Both run automatically in GitHub Actions on every push/PR to `main`.
 
 See `.github/workflows/ci.yml` for details.
 

--- a/README.md
+++ b/README.md
@@ -274,6 +274,29 @@ services:
 
 **Note:** The server exposes port 3000 for `streamable-http` and `sse` transports. If using `stdio`, no port is exposed; the server communicates exclusively via stdin/stdout.
 
+### Bearer Token Authentication (Optional)
+
+Set `MCP_BEARER_TOKEN` to require all incoming MCP requests to include an `Authorization: Bearer <token>` header. Requests with a missing or incorrect token receive a 401 response.
+
+When unset (the default), the server runs without transport-layer authentication — the same behavior as previous versions.
+
+```bash
+# Docker
+docker run -e UNIFI_API_KEY="..." -e MCP_BEARER_TOKEN="my-secret-token" -p 3000:3000 ghcr.io/swkstudios/unifi-fabric-mcp-server
+
+# Docker Compose
+services:
+  unifi-fabric-mcp:
+    image: ghcr.io/swkstudios/unifi-fabric-mcp-server
+    environment:
+      UNIFI_API_KEY: your-api-key-here
+      MCP_BEARER_TOKEN: my-secret-token
+    ports:
+      - "3000:3000"
+```
+
+This uses FastMCP's `StaticTokenVerifier` — a single shared-secret pattern designed for LAN/VPN deployments where network-level access control is already in place. It is not intended as a standalone security boundary for public-internet deployments. See [issue #10](https://github.com/swkstudios/unifi-fabric-mcp-server/issues/10) for design context.
+
 ### Single key setup
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "unifi-fabric-mcp-server"
-version = "0.3.13"
+version = "0.3.14"
 description = "MCP server for UniFi Site Manager API"
 license = {text = "MIT"}
 requires-python = ">=3.12"

--- a/src/unifi_fabric/config.py
+++ b/src/unifi_fabric/config.py
@@ -18,6 +18,19 @@ class APIKeyConfig(BaseSettings):
     )
 
 
+class MCPTransportSettings(BaseSettings):
+    """Transport-layer settings (no UNIFI_ prefix)."""
+
+    model_config = {"env_prefix": "MCP_"}
+
+    bearer_token: str = Field(
+        default="",
+        description="Optional shared secret for bearer-token auth on HTTP transport. "
+        "When set, all incoming MCP requests must include 'Authorization: Bearer <token>'. "
+        "When empty (default), the server runs without transport auth.",
+    )
+
+
 class Settings(BaseSettings):
     """Top-level settings loaded from environment variables."""
 

--- a/src/unifi_fabric/server.py
+++ b/src/unifi_fabric/server.py
@@ -14,7 +14,7 @@ from typing import Any
 from fastmcp import FastMCP
 
 from .client import UniFiClient
-from .config import Settings
+from .config import MCPTransportSettings, Settings
 from .registry import Registry
 from .tools import (
     aggregation,
@@ -175,7 +175,16 @@ user specifically asks for ACL rules or classic rules.
   guest/IoT VLANs to prevent lateral movement between clients.
 """
 
-mcp = FastMCP("UniFi Fabric", instructions=INSTRUCTIONS, lifespan=lifespan)
+_mcp_transport = MCPTransportSettings()
+_mcp_auth = None
+if _mcp_transport.bearer_token:
+    from fastmcp.server.auth.providers.jwt import StaticTokenVerifier
+
+    _mcp_auth = StaticTokenVerifier(
+        tokens={_mcp_transport.bearer_token: {"client_id": "mcp", "scopes": []}}
+    )
+
+mcp = FastMCP("UniFi Fabric", instructions=INSTRUCTIONS, lifespan=lifespan, auth=_mcp_auth)
 
 
 def _require() -> tuple[UniFiClient, Registry]:

--- a/tests/test_bearer_auth.py
+++ b/tests/test_bearer_auth.py
@@ -1,0 +1,107 @@
+"""Tests for optional MCP_BEARER_TOKEN bearer-token authentication."""
+
+from __future__ import annotations
+
+import importlib
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+TOKEN = "test-secret-token-1234"  # noqa: S105 — test-only value
+
+
+def _reload_server(monkeypatch, *, token: str = ""):
+    """Reload server module with MCP_BEARER_TOKEN set (or cleared)."""
+    if token:
+        monkeypatch.setenv("MCP_BEARER_TOKEN", token)
+    else:
+        monkeypatch.delenv("MCP_BEARER_TOKEN", raising=False)
+
+    # Must also set a valid API key so Settings() doesn't fail at import time
+    monkeypatch.setenv("UNIFI_API_KEY", "sk-reload-test")
+
+    import unifi_fabric.server as srv
+
+    importlib.reload(srv)
+    return srv
+
+
+# ---------------------------------------------------------------------------
+# Config layer
+# ---------------------------------------------------------------------------
+
+
+class TestMCPTransportSettings:
+    def test_reads_bearer_token_from_env(self, monkeypatch):
+        monkeypatch.setenv("MCP_BEARER_TOKEN", TOKEN)
+        from unifi_fabric.config import MCPTransportSettings
+
+        cfg = MCPTransportSettings()
+        assert cfg.bearer_token == TOKEN
+
+    def test_defaults_to_empty(self, monkeypatch):
+        monkeypatch.delenv("MCP_BEARER_TOKEN", raising=False)
+        from unifi_fabric.config import MCPTransportSettings
+
+        cfg = MCPTransportSettings()
+        assert cfg.bearer_token == ""
+
+
+# ---------------------------------------------------------------------------
+# Server wiring
+# ---------------------------------------------------------------------------
+
+
+class TestBearerTokenServerWiring:
+    def test_auth_enabled_when_token_set(self, monkeypatch):
+        srv = _reload_server(monkeypatch, token=TOKEN)
+        assert srv.mcp.auth is not None
+
+    def test_auth_disabled_when_token_unset(self, monkeypatch):
+        srv = _reload_server(monkeypatch, token="")
+        assert srv.mcp.auth is None
+
+
+# ---------------------------------------------------------------------------
+# StaticTokenVerifier behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestStaticTokenVerifier:
+    async def test_correct_token_accepted(self):
+        from fastmcp.server.auth.providers.jwt import StaticTokenVerifier
+
+        verifier = StaticTokenVerifier(tokens={TOKEN: {"client_id": "mcp", "scopes": []}})
+        result = await verifier.verify_token(TOKEN)
+        assert result is not None
+        assert result.client_id == "mcp"
+
+    async def test_wrong_token_rejected(self):
+        from fastmcp.server.auth.providers.jwt import StaticTokenVerifier
+
+        verifier = StaticTokenVerifier(tokens={TOKEN: {"client_id": "mcp", "scopes": []}})
+        result = await verifier.verify_token("wrong-token")
+        assert result is None
+
+    async def test_empty_token_rejected(self):
+        from fastmcp.server.auth.providers.jwt import StaticTokenVerifier
+
+        verifier = StaticTokenVerifier(tokens={TOKEN: {"client_id": "mcp", "scopes": []}})
+        result = await verifier.verify_token("")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility
+# ---------------------------------------------------------------------------
+
+
+class TestBackwardCompatibility:
+    def test_no_auth_when_env_unset(self, monkeypatch):
+        """Ensure existing deployments without MCP_BEARER_TOKEN keep working."""
+        srv = _reload_server(monkeypatch, token="")
+        # auth=None means no transport auth — same as pre-0.3.14 behaviour
+        assert srv.mcp.auth is None
+        # FastMCP instance still functional
+        assert srv.mcp.name == "UniFi Fabric"


### PR DESCRIPTION
Add opt-in `MCP_BEARER_TOKEN` env var for HTTP transport authentication. When set, requires `Authorization: Bearer <token>` on all requests (401 otherwise). Backward compatible when unset. Closes #10. Version bump 0.3.13 to 0.3.14.