### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# CODEOWNERS -- swkstudios/unifi-fabric-mcp-server
+# All files require review from the repository owner.
+* @swkstudios


### PR DESCRIPTION
Adds `.github/CODEOWNERS` requiring review from `@swkstudios` on all files. Part of repo governance hardening.